### PR TITLE
Github Actions for CI and build validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Restore packages
+      run: msbuild RAWGPlaynitePlugin.sln /t:restore
+    - name: Build
+      run: msbuild RAWGPlaynitePlugin.sln /t:build


### PR DESCRIPTION
Github provides free builds for open source projects. This is nice to have the green checkmark next to commits, but also to validate any future work on the project.

Example of a successful job: https://github.com/scowalt/RAWGPlaynitePlugin/runs/1807931226?check_suite_focus=true