### PR TITLE
Playnite 9 support

### DIFF
--- a/RAWGMetadata/RAWGMetadata.csproj
+++ b/RAWGMetadata/RAWGMetadata.csproj
@@ -95,7 +95,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="PlayniteSDK">
-      <Version>5.4.0</Version>
+      <Version>6.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/RAWGMetadata/RawgLazyMetadataProvider.cs
+++ b/RAWGMetadata/RawgLazyMetadataProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Playnite.SDK;
-using Playnite.SDK.Metadata;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 using Rawg.Api;
@@ -45,7 +44,16 @@ namespace RAWGMetadata
                 _initialized = true;
 
                 string platformId = null;
-                var platform = _options.GameData.Platform.Name;
+                var platform = string.Empty;
+                if (_options.GameData.Platforms != null && _options.GameData.Platforms.Count >= 1)
+                {
+                    platform = _options.GameData.Platforms[0].Name;
+                }
+                else
+                {
+                    return;
+                }
+                
                 if (_plugin.PlatformTranslationTable.ContainsKey(platform))
                 {
                     platform = _plugin.PlatformTranslationTable[platform];
@@ -88,8 +96,8 @@ namespace RAWGMetadata
                 }
             }
         }
-        
-        public override string GetName()
+
+        public override string GetName(GetMetadataFieldArgs args)
         {
             GetGame();
 
@@ -101,10 +109,10 @@ namespace RAWGMetadata
                 }
             }
 
-            return base.GetName();
+            return base.GetName(args);
         }
-        
-        public override List<string> GetGenres()
+
+        public override IEnumerable<MetadataProperty> GetGenres(GetMetadataFieldArgs args)
         {
             GetGameInfo();
 
@@ -112,15 +120,15 @@ namespace RAWGMetadata
             {
                 if (_gameInfo.Genres != null)
                 {
-                    return _gameInfo.Genres.Select(genre => genre.Name).ToList();
+                    return _gameInfo.Genres.Select(genre => new MetadataNameProperty(genre.Name)).ToList();
                 }
             }
 
-            return base.GetGenres();
+            return base.GetGenres(args);
         }
-        
-        
-        public override DateTime? GetReleaseDate()
+
+
+        public override ReleaseDate? GetReleaseDate(GetMetadataFieldArgs args)
         {
             GetGame();
             
@@ -128,14 +136,19 @@ namespace RAWGMetadata
             {
                 if (_game.Released != null)
                 {
-                    return _game.Released;
+                    return new ReleaseDate
+                    (
+                        _game.Released.Value.Year,
+                        _game.Released.Value.Month,
+                        _game.Released.Value.Day
+                    );
                 }
             }
 
-            return base.GetReleaseDate();
+            return base.GetReleaseDate(args);
         }
-        
-        public override List<string> GetDevelopers()
+
+        public override IEnumerable<MetadataProperty> GetDevelopers(GetMetadataFieldArgs args)
         {
             GetGameInfo();
 
@@ -143,14 +156,14 @@ namespace RAWGMetadata
             {
                 if (_gameInfo.Developers != null)
                 {
-                    return _gameInfo.Developers.Select(developer => developer.Name).ToList();
+                    return _gameInfo.Developers.Select(developer => new MetadataNameProperty(developer.Name)).ToList();
                 }
             }
 
-            return base.GetDevelopers();
+            return base.GetDevelopers(args);
         }
 
-        public override List<string> GetPublishers()
+        public override IEnumerable<MetadataProperty> GetPublishers(GetMetadataFieldArgs args)
         {
             GetGameInfo();
 
@@ -158,15 +171,15 @@ namespace RAWGMetadata
             {
                 if (_gameInfo.Publishers != null)
                 {
-                    return _gameInfo.Publishers.Select(publisher => publisher.Name).ToList();
+                    return _gameInfo.Publishers.Select(publisher => new MetadataNameProperty(publisher.Name)).ToList();
                 }
             }
 
-            return base.GetPublishers();
+            return base.GetPublishers(args);
         }
-        
 
-        public override string GetDescription()
+
+        public override string GetDescription(GetMetadataFieldArgs args)
         {
             GetGameInfo();
             
@@ -178,10 +191,10 @@ namespace RAWGMetadata
                 }
             }
 
-            return base.GetDescription();
+            return base.GetDescription(args);
         }
-        
-        public override int? GetCommunityScore()
+
+        public override int? GetCommunityScore(GetMetadataFieldArgs args)
         {
             GetGame();
 
@@ -193,10 +206,10 @@ namespace RAWGMetadata
                 }
             }
 
-            return base.GetCommunityScore();
+            return base.GetCommunityScore(args);
         }
-        
-        public override MetadataFile GetCoverImage()
+
+        public override MetadataFile GetCoverImage(GetMetadataFieldArgs args)
         {
             /*
             GetGame();
@@ -209,10 +222,10 @@ namespace RAWGMetadata
                 }
             }
             */
-            return base.GetCoverImage();
+            return base.GetCoverImage(args);
         }
         
-        public override MetadataFile GetBackgroundImage()
+        public override MetadataFile GetBackgroundImage(GetMetadataFieldArgs args)
         {
             GetGame();
 
@@ -224,10 +237,10 @@ namespace RAWGMetadata
                 }
             }
 
-            return base.GetBackgroundImage();
+            return base.GetBackgroundImage(args);
         }
-        
-        public override List<Link> GetLinks()
+
+        public override IEnumerable<Link> GetLinks(GetMetadataFieldArgs args)
         {
             GetGameInfo();
 
@@ -256,10 +269,10 @@ namespace RAWGMetadata
                 }
             }
 
-            return base.GetLinks();
+            return base.GetLinks(args);
         }
 
-        public override MetadataFile GetIcon()
+        public override MetadataFile GetIcon(GetMetadataFieldArgs args)
         {
             /*
             using (MemoryStream ms = new MemoryStream())
@@ -269,10 +282,10 @@ namespace RAWGMetadata
             }
             */
 
-            return base.GetIcon();
+            return base.GetIcon(args);
         }
         
-        public override int? GetCriticScore()
+        public override int? GetCriticScore(GetMetadataFieldArgs args)
         {
             GetGame();
 
@@ -284,10 +297,10 @@ namespace RAWGMetadata
                 }
             }
 
-            return base.GetCriticScore();
+            return base.GetCriticScore(args);
         }
-        
-        public override List<string> GetTags()
+
+        public override IEnumerable<MetadataProperty> GetTags(GetMetadataFieldArgs args)
         {
             GetGameInfo();
 
@@ -295,11 +308,11 @@ namespace RAWGMetadata
             {
                 if (_gameInfo.Tags != null)
                 {
-                    return _gameInfo.Tags.Select(tag => tag.Name).ToList();
+                    return _gameInfo.Tags.Select(tag => new MetadataNameProperty(tag.Name)).ToList();
                 }
             }
 
-            return base.GetTags();
+            return base.GetTags(args);
         }
         
 

--- a/RAWGMetadata/RawgMetadataPlugin.cs
+++ b/RAWGMetadata/RawgMetadataPlugin.cs
@@ -47,7 +47,7 @@ namespace RAWGMetadata
             { "Nintendo Switch","Nintendo Switch"},
             { "Nintendo Wii","Wii"},
             { "Nintendo Wii U","Wii U"},
-            { "PC","PC"},
+            { "PC (Windows)","PC"},
             { "Sega 32X","SEGA 32X"},
             { "Sega CD","SEGA CD"},
             { "Sega Dreamcast","Dreamcast"},
@@ -93,41 +93,6 @@ namespace RAWGMetadata
         public override UserControl GetSettingsView(bool firstRunView)
         {
             return new RawgMetadataSettingsView(this);
-        }
-
-        public override IEnumerable<ExtensionFunction> GetFunctions()
-        {
-            return base.GetFunctions();
-        }
-
-        public override void OnGameStarting(Game game)
-        {
-            base.OnGameStarting(game);
-        }
-
-        public override void OnGameStarted(Game game)
-        {
-            base.OnGameStarted(game);
-        }
-
-        public override void OnGameStopped(Game game, long ellapsedSeconds)
-        {
-            base.OnGameStopped(game, ellapsedSeconds);
-        }
-
-        public override void OnGameInstalled(Game game)
-        {
-            base.OnGameInstalled(game);
-        }
-
-        public override void OnGameUninstalled(Game game)
-        {
-            base.OnGameUninstalled(game);
-        }
-
-        public override void OnApplicationStarted()
-        {
-            base.OnApplicationStarted();
         }
 
         public override Guid Id => Guid.Parse("000001D9-DBD1-46C6-B5D0-B1BA557D10E4");

--- a/RAWGMetadata/RawgMetadataPlugin.cs
+++ b/RAWGMetadata/RawgMetadataPlugin.cs
@@ -68,6 +68,10 @@ namespace RAWGMetadata
         public RawgMetadataPlugin(IPlayniteAPI playniteAPI) : base(playniteAPI)
         {
             Settings = new RawgMetadataSettings(this);
+            Properties = new MetadataPluginProperties
+            {
+                HasSettings = false
+            };
             PlatformList = Settings.PlatformList;
             Task.Run(() => {
                 try

--- a/RAWGMetadata/extension.yaml
+++ b/RAWGMetadata/extension.yaml
@@ -1,13 +1,10 @@
 ﻿Id: Spektor56_Playnite_Metadata_RAWG
 Name: RAWG metadata provider
 Author: Spektor56
-Version: 2.0.0
+Version: 3.0.0
 Module: RAWGMetadata.dll
 Type: MetadataProvider
 Icon: Resources\rawg.ico
 Links:
   - Name: Github
     Url: https://github.com/spektor56/RAWGPlaynitePlugin
-UpdaterConfig:
-  GitHubUser: spektor56
-  GitHubRepo: RAWGPlaynitePlugin

--- a/RawgTestApp/RawgTestApp.csproj
+++ b/RawgTestApp/RawgTestApp.csproj
@@ -91,7 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="PlayniteSDK">
-      <Version>5.4.0</Version>
+      <Version>6.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/manifests/InstallerManifest.yaml
+++ b/manifests/InstallerManifest.yaml
@@ -1,0 +1,8 @@
+AddonId: Spektor56_Playnite_Metadata_RAWG
+Packages:
+  - Version: 3.0.0
+    RequiredApiVersion: 6.1.0
+    ReleaseDate: 2021-10-25
+    PackageUrl: https://github.com/spektor56/RAWGPlaynitePlugin/releases/download/3.0.0/RAWG_metadata_provider_3_0_0.pext
+    Changelog:
+      - Playnite 9 support


### PR DESCRIPTION
Changes:
- Updated to support Playnite SDK 6.1.0
- Changed platform name value from `PC` to `PC (Windows)`, since that's how the platform is named in Playnite 9 and also used by library plugins
- Removed properties in extension manifest to support extension updater extension
- Added installer manifest to support Playnite 9 Built-In addon browser and updater